### PR TITLE
StaticJavaParser and SourceRoot APIs #3415

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
@@ -65,16 +65,18 @@ public final class StaticJavaParser {
 
     /**
      * Get the configuration for the parse... methods. Deprecated method.
+     *
+     * @deprecated use {@link #getParserConfiguration()} instead
      */
     @Deprecated
     public static ParserConfiguration getConfiguration() {
-        return localConfiguration.get();
+        return getParserConfiguration();
     }
 
     /**
      * Get the configuration for the parse... methods.
      */
-    public static ParserConfiguration getParseConfiguration() {
+    public static ParserConfiguration getParserConfiguration() {
         return localConfiguration.get();
     }
 

--- a/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
@@ -66,6 +66,7 @@ public final class StaticJavaParser {
     /**
      * Get the configuration for the parse... methods.
      */
+    @Deprecated
     public static ParserConfiguration getConfiguration() {
         return localConfiguration.get();
     }

--- a/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/StaticJavaParser.java
@@ -64,10 +64,17 @@ public final class StaticJavaParser {
     }
 
     /**
-     * Get the configuration for the parse... methods.
+     * Get the configuration for the parse... methods. Deprecated method.
      */
     @Deprecated
     public static ParserConfiguration getConfiguration() {
+        return localConfiguration.get();
+    }
+
+    /**
+     * Get the configuration for the parse... methods.
+     */
+    public static ParserConfiguration getParseConfiguration() {
         return localConfiguration.get();
     }
 


### PR DESCRIPTION
Marked old method in StaticJavaParser as deprecated and created a new method that aligns with the SourceRoot method